### PR TITLE
chain addr prefix variable

### DIFF
--- a/contracts/factory/schema/instantiate_msg.json
+++ b/contracts/factory/schema/instantiate_msg.json
@@ -3,10 +3,14 @@
   "title": "InstantiateMsg",
   "type": "object",
   "required": [
+    "addr_prefix",
     "proxy_code_id",
     "proxy_multisig_code_id"
   ],
   "properties": {
+    "addr_prefix": {
+      "type": "string"
+    },
     "proxy_code_id": {
       "type": "integer",
       "format": "uint64",

--- a/contracts/factory/src/msg.rs
+++ b/contracts/factory/src/msg.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 pub struct InstantiateMsg {
     pub proxy_code_id: u64,
     pub proxy_multisig_code_id: u64,
+    pub addr_prefix: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]

--- a/contracts/factory/src/state.rs
+++ b/contracts/factory/src/state.rs
@@ -13,3 +13,5 @@ pub const PROXY_CODE_ID: Item<u64> = Item::new("proxy_code_id");
 pub const PROXY_MULTISIG_CODE_ID: Item<u64> = Item::new("proxy_multisig_code_id");
 /// All created wallets by CanonicalAddr
 pub const WALLETS: Map<&[u8], ()> = Map::new("wallets");
+/// Chain address prefix
+pub const ADDR_PREFIX: Item<String> = Item::new("addr_prefix");

--- a/contracts/factory/src/tests.rs
+++ b/contracts/factory/src/tests.rs
@@ -6,11 +6,17 @@ use crate::contract::{execute, instantiate, query_proxy_code_id, query_wallet_li
 use crate::msg::{ExecuteMsg, InstantiateMsg, WalletListResponse};
 
 // this will set up the instantiation for other tests
-fn do_instantiate(mut deps: DepsMut, proxy_code_id: u64, proxy_multisig_code_id: u64) {
+fn do_instantiate(
+    mut deps: DepsMut,
+    proxy_code_id: u64,
+    proxy_multisig_code_id: u64,
+    addr_prefix: &str,
+) {
     // we do not do integrated tests here so code ids are arbitrary
     let instantiate_msg = InstantiateMsg {
         proxy_code_id,
         proxy_multisig_code_id,
+        addr_prefix: addr_prefix.to_string(),
     };
     let info = mock_info("admin", &[]);
     let env = mock_env();
@@ -22,7 +28,7 @@ fn do_instantiate(mut deps: DepsMut, proxy_code_id: u64, proxy_multisig_code_id:
 fn initialise_with_no_wallets() {
     let mut deps = mock_dependencies();
 
-    do_instantiate(deps.as_mut(), 0, 1);
+    do_instantiate(deps.as_mut(), 0, 1, "wasm");
 
     // no wallets to start
     let wallets: WalletListResponse = query_wallet_list(deps.as_ref()).unwrap();
@@ -34,7 +40,13 @@ fn initialise_with_correct_code_id() {
     let mut deps = mock_dependencies();
     let initial_code_id = 1111;
     let initial_multisig_code_id = 2222;
-    do_instantiate(deps.as_mut(), initial_code_id, initial_multisig_code_id);
+    let addr_prefix = "wasm";
+    do_instantiate(
+        deps.as_mut(),
+        initial_code_id,
+        initial_multisig_code_id,
+        addr_prefix,
+    );
     let proxy_code_id = query_proxy_code_id(deps.as_ref()).unwrap();
     assert_eq!(proxy_code_id, initial_code_id);
 }
@@ -45,7 +57,12 @@ fn admin_upgrade_proxy_code_id_works() {
     let initial_code_id = 1111;
     let new_code_id = 2222;
     let initial_multisig_code_id = 2222;
-    do_instantiate(deps.as_mut(), initial_code_id, initial_multisig_code_id);
+    do_instantiate(
+        deps.as_mut(),
+        initial_code_id,
+        initial_multisig_code_id,
+        "wasm",
+    );
     let proxy_code_id = query_proxy_code_id(deps.as_ref()).unwrap();
     assert_eq!(proxy_code_id, initial_code_id);
 

--- a/contracts/factory/tests/common.rs
+++ b/contracts/factory/tests/common.rs
@@ -116,6 +116,7 @@ impl Suite {
                 &InstantiateMsg {
                     proxy_code_id,
                     proxy_multisig_code_id,
+                    addr_prefix: "wasm".to_string(),
                 }, // InstantiateMsg
                 &init_funds,
                 "wallet-factory", // label: human readible name for contract

--- a/contracts/proxy/schema/instantiate_msg.json
+++ b/contracts/proxy/schema/instantiate_msg.json
@@ -3,12 +3,16 @@
   "title": "InstantiateMsg",
   "type": "object",
   "required": [
+    "addr_prefix",
     "code_id",
     "create_wallet_msg",
-    "factory",
     "multisig_code_id"
   ],
   "properties": {
+    "addr_prefix": {
+      "description": "Chain address prefix",
+      "type": "string"
+    },
     "code_id": {
       "description": "Code Id used to instantiate the contract",
       "type": "integer",
@@ -18,14 +22,6 @@
     "create_wallet_msg": {
       "$ref": "#/definitions/CreateWalletMsg"
     },
-    "factory": {
-      "description": "Factory address",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Addr"
-        }
-      ]
-    },
     "multisig_code_id": {
       "description": "Fixed Multisig Code Id for guardians",
       "type": "integer",
@@ -34,10 +30,6 @@
     }
   },
   "definitions": {
-    "Addr": {
-      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-      "type": "string"
-    },
     "Binary": {
       "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
       "type": "string"

--- a/contracts/proxy/src/msg.rs
+++ b/contracts/proxy/src/msg.rs
@@ -9,10 +9,10 @@ pub struct InstantiateMsg {
     pub create_wallet_msg: CreateWalletMsg,
     /// Fixed Multisig Code Id for guardians
     pub multisig_code_id: u64,
-    /// Factory address
-    pub factory: Addr,
     /// Code Id used to instantiate the contract
     pub code_id: u64,
+    /// Chain address prefix
+    pub addr_prefix: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/proxy/src/state.rs
+++ b/contracts/proxy/src/state.rs
@@ -56,3 +56,5 @@ pub const GUARDIANS: Map<&[u8], ()> = Map::new("guardians");
 pub const RELAYERS: Map<&[u8], ()> = Map::new("relayers");
 // An address of fixed multisig contract, used for guardians multisig support.
 pub const MULTISIG_ADDRESS: Item<CanonicalAddr> = Item::new("fixed_multisig_address");
+/// Chain address prefix
+pub const ADDR_PREFIX: Item<String> = Item::new("addr_prefix");

--- a/contracts/proxy/src/tests.rs
+++ b/contracts/proxy/src/tests.rs
@@ -58,14 +58,14 @@ fn do_instantiate(mut deps: DepsMut) -> Addr {
     let instantiate_msg = InstantiateMsg {
         create_wallet_msg,
         multisig_code_id: MULTISIG_CODE_ID,
-        factory: Addr::unchecked("factory"),
         code_id: 0,
+        addr_prefix: "wasm".to_string(),
     };
 
     let info = mock_info("creator", &[]);
     let env = mock_env();
 
-    let address = pub_key_to_address(&deps, &public_key_serialized).unwrap();
+    let address = pub_key_to_address(&deps, "wasm", &public_key_serialized).unwrap();
     instantiate(deps.branch(), env, info, instantiate_msg).unwrap();
     address
 }

--- a/js-app/src/e2e.spec.ts
+++ b/js-app/src/e2e.spec.ts
@@ -77,6 +77,7 @@ describe("End to End testing: ", () => {
       {
         proxy_code_id: proxyRes.codeId,
         proxy_multisig_code_id: multisigRes.codeId,
+		addr_prefix: "wasm"
       },
       "wallet factory",
       defaultInstantiateFee,
@@ -88,6 +89,7 @@ describe("End to End testing: ", () => {
       instantiateMsg: {
         proxy_code_id: proxyRes.codeId,
         proxy_multisig_code_id: multisigRes.codeId,
+		addr_prefix: "wasm"
       },
       address: contractAddress,
       initialFund: [initialFund],

--- a/js-app/src/util/tests.ts
+++ b/js-app/src/util/tests.ts
@@ -97,6 +97,7 @@ export interface FactoryInstance {
   readonly instantiateMsg: {
     readonly proxy_code_id: number;
     readonly proxy_multisig_code_id: number;
+    readonly addr_prefix: string;
   };
   readonly address: string;
   readonly initialFund: Coin[];

--- a/packages/factory/src/pubkey.rs
+++ b/packages/factory/src/pubkey.rs
@@ -7,12 +7,12 @@ use ripemd160::Ripemd160;
 use sha2::Sha256;
 
 /// Converts user pubkey into Addr
-pub fn pub_key_to_address(deps: &DepsMut, pub_key: &[u8]) -> StdResult<Addr> {
+pub fn pub_key_to_address(deps: &DepsMut, prefix: &str, pub_key: &[u8]) -> StdResult<Addr> {
     let compressed_pub_key = to_compressed_pub_key(pub_key)?;
     let mut ripemd160_hasher = Ripemd160::new();
     ripemd160_hasher.update(Sha256::digest(&compressed_pub_key));
     let addr_bytes = ripemd160_hasher.finalize().to_vec();
-    let addr_str = bech32::encode("wasm", addr_bytes.to_base32(), Variant::Bech32).unwrap();
+    let addr_str = bech32::encode(prefix, addr_bytes.to_base32(), Variant::Bech32).unwrap();
     deps.api.addr_validate(&addr_str)
 }
 


### PR DESCRIPTION
- allow chain addr prefix to be param for different chains, closes #1 
- removed Proxy InstantiateMsg.factor (use `info.sender` repeats the same info)