### PR TITLE
Align Query::Balances interface with cw20 interface and transfer balance when updating DAO

### DIFF
--- a/cli/core/utils/dao-params.ts
+++ b/cli/core/utils/dao-params.ts
@@ -16,9 +16,9 @@ export const walletFee: Coin = { amount: "10000", denom: coinMinDenom! };
 export const unstakeDuration: StakeDuration | null = null;
 // Deposit required for creating proposal
 export const depositInfo: DepositInfo | null = null;
-// Length of  , Time in seconds
+// Length of  max Voting Period, Time in seconds
 export const maxVotingPeriod: Duration | null = { time: 60 * 60 * 24 * 14 };
-// Length of  , Time in seconds
+// Length of  min Voting Period , Time in seconds
 export const minVotingPeriod: Duration | null = null;
 // Can members change their votes before expiry
 // It is easier for it to be false for deployment

--- a/contracts/govec/src/msg.rs
+++ b/contracts/govec/src/msg.rs
@@ -75,14 +75,19 @@ pub enum ExecuteMsg {
     /// If authorized, creates 1 new vote token and adds to the new wallets .
     Mint { new_wallet: String },
     /// Updates the staking contract address.Authorized by the DAO
+    /// permission: executed by dao only
     UpdateStakingAddr { new_addr: String },
     /// Updates the minter contract address.Authorized by the DAO
+    /// permission: executed by dao only
     UpdateMintData { new_mint: Option<MinterData> },
     /// Updates the DAO address for this governance token
+    /// All balance from old DAO will go to the new DAO
+    /// permission: executed by dao only
     UpdateDaoAddr { new_addr: String },
     /// If authorized, updates marketing metadata.
     /// Setting None/null for any of these will leave it unchanged.
     /// Setting Some("") will clear this field on the contract storage
+    /// permission: executed by dao only
     UpdateMarketing {
         /// A URL pointing to the project behind this token.
         project: Option<String>,
@@ -101,6 +106,10 @@ pub enum QueryMsg {
     /// Returns the current balance of the given address, 0 if unset.
     /// Return type: BalanceResponse.
     Balance { address: String },
+    /// Returns Some(balance) if address has ever been issued a token,
+    /// If the current balance is 0, returns Some(0)
+    /// IF address has never been issued a token, None is returned
+    Joined { address: String },
     /// Returns metadata on the contract - name, decimals, supply, etc.
     /// Return type: TokenInfoResponse.
     TokenInfo {},

--- a/contracts/govec/src/tests.rs
+++ b/contracts/govec/src/tests.rs
@@ -155,6 +155,44 @@ fn cannot_mint_over_cap() {
 }
 
 #[test]
+fn query_joined_works() {
+    let mut deps = mock_dependencies();
+    let genesis = String::from("genesis");
+    let not_genesis = String::from("not_genesis");
+    let amount = Uint128::new(10);
+    let limit = Uint128::new(12);
+
+    do_instantiate(
+        deps.as_mut(),
+        vec![genesis.as_str()],
+        vec![amount],
+        DAO_ADDR,
+        Some(limit),
+        None,
+    );
+
+    assert_eq!(
+        query_balance(deps.as_ref(), genesis.clone())
+            .unwrap()
+            .balance,
+        amount
+    );
+    assert_eq!(
+        query_balance(deps.as_ref(), not_genesis.clone())
+            .unwrap()
+            .balance,
+        Uint128::zero()
+    );
+
+    assert!(query_balance_joined(deps.as_ref(), genesis)
+        .unwrap()
+        .is_some());
+    assert!(query_balance_joined(deps.as_ref(), not_genesis)
+        .unwrap()
+        .is_none());
+}
+
+#[test]
 fn dao_can_update_staking_addr() {
     let mut deps = mock_dependencies();
     let genesis = String::from("genesis");


### PR DESCRIPTION
- added new query to see if addr has joined
- `Query::Balance` returns zero if addr has not joined
- transfer all exisiting DAO token to new DAO on `execute_update_dao`